### PR TITLE
Update parameters for building lambda dependencies

### DIFF
--- a/once/utils.py
+++ b/once/utils.py
@@ -87,9 +87,10 @@ def make_python_zip_bundle(input_path: str,
 
         # builds requirements using target runtime
         build_log = execute_shell_command(command=[
-            'docker', 'run', '--rm',
+            docker, 'run', '--rm',
             '-v', f'{input_path}:/app',
             '-w', '/app',
+            '-u', '$(id -u):$(id -g)',
             lambda_runtime_docker_image,
                 'pip', 'install',
                 '-r', requirements_file,


### PR DESCRIPTION
Hi @domtes,

I added the parameter `-u $(id -u):$(id -g)` for building the lambda dependencies as a user and the variable `docker` instead of putting it as a string.

I enjoyed learning about `CDK` with this repository, it is very well explained and it is an excellent example for starting with.

PD: I suggest using `black` formatter.

Best regards,

Demetrio.